### PR TITLE
Fixes #2 getDict did not handle nested cdrs

### DIFF
--- a/test/python/test.py
+++ b/test/python/test.py
@@ -54,6 +54,22 @@ class TestCdr(unittest.TestCase):
         self.assertEqual(e.getString(1), f[0].getString(1))
         self.assertEqual(e.getString(2), f[0].getString(2))
 
+    def test_to_python_dict(self):
+        d = Cdr()
+        e = Cdr()
+        f = Cdr()
+
+        f[21] = 400
+
+        e[11] = 300
+        e[12] = [f]
+
+        d[1] = 100
+        d[2] = 200
+
+        d[3] = [e]
+        assert(d.toPythonDict()[3][0][12][0][21] == 400)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- getDict has now been renamed toPythonDict, a more appropriate name
- toPythonDict is now recursive and so handles nested cdrs
- added a unittest to validate that following a toPythonDict call the
resulting dict can be recursively accessed