### PR TITLE
[STYLE] Using lists for target_link_dependencies and add_library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,10 +5,14 @@ set(CDR_HEADERS
   cdr.h
   )
 
+set (CDR_SOURCES cdr.cpp)
+
 if(WIN32)
   set(CDR_HEADERS ${CDR_HEADERS} asprintf.h)
+  set(CDR_SOURCES ${CDR_SOURCES}
+                  asprintf.cpp
+                  vasprintf.cpp)
 endif()
-
 
 install(FILES ${CDR_HEADERS}
   DESTINATION include/cdr
@@ -19,17 +23,7 @@ include_directories(
   )
 
 
-if(WIN32)
-add_library(cdr SHARED
-  cdr.cpp
-  asprintf.cpp
-  vasprintf.cpp
-  )
-else()
-add_library(cdr SHARED
-  cdr.cpp
-  )
-endif()
+add_library(cdr SHARED ${CDR_SOURCES})
 
 install(TARGETS cdr
   EXPORT ${PROJECT_NAME}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,23 +10,17 @@ include_directories(
 link_directories(${CMAKE_BINARY_DIR}/googletest/lib)
 
 file(GLOB SRC_FILES ${PROJECT_SOURCE_DIR}/test/*.cc)
+set (LIBS cdr
+          gtest
+          gmock)
+
+if(NOT WIN32)
+    set (LIBS "${LIBS}"
+              pthread)
+endif()
   
 add_executable(unittest ${SRC_FILES})
-
-if(WIN32)
-target_link_libraries(unittest
-  cdr
-  gtest
-  gmock
-  )
-else()
-target_link_libraries(unittest
-  cdr
-  gtest
-  gmock
-  pthread
-  )
-endif()
+target_link_libraries(unittest ${LIBS})
 
 add_test(NAME unittest
   COMMAND unittest


### PR DESCRIPTION
Files required by different platforms get appended to the list and only one target_link_dependencies or add_libaray is used.