### PR TITLE
Feature/python version support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ option(PYTHON "Enable Python bindings" OFF)
 option(CSHARP "Enable C# bindings" OFF)
 option(COVERAGE "Enable gcov coverage" OFF)
 option(EXAMPLES "Enable examples" ON)
-set(PYTHON_VER "3" CACHE STRING "Python version to build with")
+set(PYTHON_CONFIG "python-config" CACHE STRING "python-config for build env config")
 
 if(COVERAGE)
     set(COVERAGE_COMPILE_FLAGS "-g -O0 -coverage -fprofile-arcs -ftest-coverage")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ option(PYTHON "Enable Python bindings" OFF)
 option(CSHARP "Enable C# bindings" OFF)
 option(COVERAGE "Enable gcov coverage" OFF)
 option(EXAMPLES "Enable examples" ON)
+set(PYTHON_VER "3" CACHE STRING "Python version to build with")
 
 if(COVERAGE)
     set(COVERAGE_COMPILE_FLAGS "-g -O0 -coverage -fprofile-arcs -ftest-coverage")

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -2,8 +2,8 @@
 # Copyright 2014-2018 Neueda Ltd.
 #
 # Include python
-find_package(PythonInterp REQUIRED)
-find_package(PythonLibs REQUIRED)
+find_package(PythonInterp ${PYTHON_VER} REQUIRED)
+find_package(PythonLibs ${PYTHON_VER} REQUIRED)
 include_directories(${PYTHON_INCLUDE_PATH})
 
 # set the flags for swig

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -2,17 +2,55 @@
 # Copyright 2014-2018 Neueda Ltd.
 #
 # Include python
-find_package(PythonInterp ${PYTHON_VER} REQUIRED)
-find_package(PythonLibs ${PYTHON_VER} REQUIRED)
-include_directories(${PYTHON_INCLUDE_PATH})
+# find_package(PythonInterp ${PYTHON_VER} REQUIRED)
+# find_package(PythonLibs ${PYTHON_VER} REQUIRED)
+# include_directories(${PYTHON_INCLUDE_PATH})
 
 # set the flags for swig
 set(CMAKE_SWIG_FLAGS "")
 set_source_files_properties(../cdr.py.i PROPERTIES CPLUSPLUS ON)
 
+execute_process(
+    COMMAND bash -c "${PYTHON_CONFIG} --includes"
+    OUTPUT_VARIABLE PYTHON_INCLUDE_PATH
+    RESULT_VARIABLE RET
+    )
+if(NOT ${RET} EQUAL "0")
+    message(FATAL_ERROR "failed to run python-config --includes")
+endif()
+
+execute_process(
+    COMMAND bash -c "${PYTHON_CONFIG} --ldflags"
+    OUTPUT_VARIABLE PYTHON_LDFLAGS
+    RESULT_VARIABLE RET
+    )
+if(NOT ${RET} EQUAL "0")
+    message(FATAL_ERROR "failed to run python-config --ldflags")
+endif()
+
+execute_process(
+    COMMAND bash -c "${PYTHON_CONFIG} --libs"
+    OUTPUT_VARIABLE PYTHON_LIBS
+    RESULT_VARIABLE RET
+    )
+if(NOT ${RET} EQUAL "0")
+    message(FATAL_ERROR "failed to run python-config --libs")
+endif()
+
+string(STRIP ${PYTHON_LDFLAGS} PYTHON_LDFLAGS)
+string(STRIP ${PYTHON_INCLUDE_PATH} PYTHON_INCLUDE_PATH)
+string(STRIP ${PYTHON_LIBS} PYTHON_LIBS)
+
+message(STATUS "Python includes: ${PYTHON_INCLUDE_PATH}")
+message(STATUS "Python ldflags: ${PYTHON_LDFLAGS}")
+message(STATUS "Python libs: ${PYTHON_LIBS}")
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${PYTHON_INCLUDE_PATH}")
+link_libraries(${PYTHON_LDFLAGS})
+
 # Add swig module
 swig_add_module(cdr python ../cdr.py.i)
-swig_link_libraries(cdr cdr ${PYTHON_LIBRARIES})
+swig_link_libraries(cdr cdr ${PYTHON_LIBS})
 
 # Files to install with Python
 set(PYTHON_INSTALL_FILES

--- a/src/cdr.cpp
+++ b/src/cdr.cpp
@@ -776,7 +776,7 @@ cdr::deserializeItem (const char* data, size_t& used)
             used += sizeof (int64_t);
 
             tm tm;
-            gmtime_r (&epoch, &tm);
+            gmtime_r ((time_t*)(&epoch), &tm);
 
             cdrItem item (CDR_DATETIME);
             item.mDateTime.mHour = tm.tm_hour;


### PR DESCRIPTION
Fixes #25 

- using a more robust python detection mechanism: python-config
- leverage swig compatibility functions to achieve py2 and py3 version compatibility
- also minor fixes for OS X  

